### PR TITLE
Add ClawBench (Web Agents subsection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,17 @@ We welcome contributions! Please read our [CONTRIBUTING.md](CONTRIBUTING.md) for
 
 ### Agent Capabilities & Reasoning
 
+#### Web Agents
+
+- **ClawBench** - Live-website browser agent benchmark with two-stage scoring (HTTP-request interception + LLM judge on payload)
+  - Code: https://github.com/reacher-z/ClawBench
+  - Paper: https://arxiv.org/abs/2604.08523
+  - Website: https://claw-bench.com
+  - Dataset: https://huggingface.co/datasets/NAIL-Group/ClawBench
+  - Year: 2026
+  - Tags: web agent, browser agent, live websites, interception, LLM judge, real-world tasks
+
+
 #### Swarm Intelligence
 - **SwarmBench** - Benchmarking LLMs' Swarm Intelligence
   - Code: https://github.com/RUC-GSAI/YuLan-SwarmIntell


### PR DESCRIPTION
Adds a new **Web Agents** subsection under **Agent Capabilities & Reasoning** with **ClawBench** as the first entry.

ClawBench evaluates browser agents on **live production websites** (real Uber Eats, Indeed, Craigslist, etc., not synthetic). Two-stage scoring: deterministic HTTP-request **interception** at per-task URL/method schema + **LLM judge** on the intercepted payload.

- 283 tasks (V1 153 + V2 130) across 163 live platforms · 15 life categories
- Paper: https://arxiv.org/abs/2604.08523 · Code: https://github.com/reacher-z/ClawBench
- Live leaderboard: https://claw-bench.com

I noticed Agent Capabilities & Reasoning has Swarm Intelligence and Long-term Coherence subsections but no Web Agents grouping yet — happy to keep ClawBench as a flat entry instead, or move under a different parent if you prefer.

Affiliation: I'm one of the maintainers; happy to adjust copy or section placement.
