### PR TITLE
Add ContextBenchmark (new Reliability & Reproducibility subcategory)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A curated list of 100+ AI benchmarks across various domains including Agent Capa
     - [Long-term Coherence](#long-term-coherence)
     - [Scientific & Academic Reasoning](#scientific--academic-reasoning)
     - [Security & Robustness](#security--robustness)
+    - [Reliability & Reproducibility](#reliability--reproducibility)
     - [Business & CRM](#business--crm)
     - [World Modeling & Simulation](#world-modeling--simulation)
     - [Game & Interactive](#game--interactive)
@@ -42,10 +43,10 @@ A curated list of 100+ AI benchmarks across various domains including Agent Capa
 
 ## 📊 Statistics
 
-- **Total Benchmarks**: 114
+- **Total Benchmarks**: 118
 - **Categories**: 6
-- **Subcategories**: 24
-- **Last Updated**: 2026-01-08
+- **Subcategories**: 25
+- **Last Updated**: 2026-07-05
 
 ## 🚀 Website
 
@@ -726,6 +727,14 @@ We welcome contributions! Please read our [CONTRIBUTING.md](CONTRIBUTING.md) for
   - Paper: https://arxiv.org/pdf/2505.10013
   - Year: 2025
   - Tags: bias evaluation, implicit bias, fairness, social bias, verification
+
+#### Reliability & Reproducibility
+- **ContextBenchmark** - Open, vendor-neutral benchmark measuring the reliability, reproducibility, and determinism of AI context systems (retrieval indexes, RAG pipelines, agent memory, and code-context engines) through rebuild-identity, query-stability, drift-under-noise, and cross-machine identity tests, graded as Context Trust Levels (CTL 0-4) with verifiable per-adapter fingerprints
+  - Website: https://contextbenchmark.com
+  - Code: https://github.com/aabhisrv/contextbenchmark
+  - Year: 2026
+  - Metrics: Exact-Match Rate, Jaccard@k, Kendall tau, Drift score, Artifact hash (SHA-256), Context Trust Level (CTL 0-4)
+  - Tags: reproducibility, determinism, reliability, retrieval, rag, agent-memory, code-context, fingerprint
 
 #### Business & CRM
 - **CRMArena-Pro** - Holistic Assessment of LLM Agents Across Diverse Business Scenarios and Interactions


### PR DESCRIPTION
This adds **ContextBenchmark**, an open, vendor-neutral benchmark that measures the *reliability, reproducibility, and determinism* of AI context systems (retrieval indexes, RAG pipelines, agent memory, and code-context engines).

### Why a new subcategory
The catalog currently has no home for determinism / reproducibility of context or retrieval systems. The closest existing subcategory, `Memory & Episodic Tasks`, measures memory *capability* (can the model recall X), not reproducibility (does the retrieval layer return the *same* result twice, across rebuilds, and across machines). This PR introduces a `Reliability & Reproducibility` subcategory under `Agent Capabilities & Reasoning`, as a sibling to `Security & Robustness`.

### What it measures
- Rebuild identity, query stability, drift-under-noise, and cross-machine identity
- Graded as Context Trust Levels (CTL 0-4) with verifiable per-adapter fingerprints (SHA-256 artifact hashes)
- Metrics: Exact-Match Rate, Jaccard@k, Kendall tau, Drift score, Artifact hash, CTL

### Compliance
- Website-backed entry (same style as existing website-only entries such as the Creative Writing benchmarks)
- Passes `website/scripts/validate-readme.js` locally (118 benchmarks, 6 categories, 0 errors)
- Website: https://contextbenchmark.com  Code: https://github.com/aabhisrv/contextbenchmark

Happy to adjust placement or wording if you would prefer it live under a different parent category.